### PR TITLE
Changing version on download button to 0.9.7

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -52,7 +52,7 @@
             <div class="try-btn">
                 <a href="https://github.com/phalcon/zephir" class="btn btn-pink">
                     <i class="fa fa-download"></i> Download
-                    <span class="description">Zephir version 0.9.4</span>
+                    <span class="description">Zephir version 0.9.7</span>
                 </a>
                 <a href="#" class="btn btn-blue">
                     <i class="fa fa-play-circle-o"></i> A small taste


### PR DESCRIPTION
Just changing version shown on Download button.

_As a suggestion it could only show something like **Zephir version 0.9+** for future minor releases._